### PR TITLE
Assert dispose on close window

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -2,6 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:NWNLogRotator"
-             StartupUri="NWNLogRotator.xaml">
+             StartupUri="NWNLogRotator.xaml"
+             Exit="DisposeNotifyIcon">
     <Application.Resources></Application.Resources>
 </Application>

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using NWNLogRotator.Classes;
+using System.Windows;
 
 namespace NWNLogRotator
 {
@@ -7,5 +8,9 @@ namespace NWNLogRotator
     /// </summary>
     public partial class App : Application
     {
+        public void DisposeNotifyIcon(object sender, ExitEventArgs e)
+        {
+            NWNLogRotator.MainWindow.ExitEvent();
+        }
     }
 }

--- a/NWNLogRotator.xaml.cs
+++ b/NWNLogRotator.xaml.cs
@@ -722,6 +722,9 @@ namespace NWNLogRotator
         private void WindowClosed_Event(object sender, CancelEventArgs e)
         {
             ni.Visible = false;
+            ni.Icon = null;
+            ni.Dispose();
+            System.Windows.Forms.Application.DoEvents();
         }
 
         /*

--- a/NWNLogRotator.xaml.cs
+++ b/NWNLogRotator.xaml.cs
@@ -27,7 +27,7 @@ namespace NWNLogRotator
     {
         FileHandler FileHandlerInstance = new FileHandler();
         Settings _settings;
-        System.Windows.Forms.NotifyIcon ni = new System.Windows.Forms.NotifyIcon();
+        static System.Windows.Forms.NotifyIcon ni = new System.Windows.Forms.NotifyIcon();
         Notification notification = new Notification();
         private int ClientLauncherState = 0;
         private string ProcessName = "nwmain";
@@ -37,6 +37,7 @@ namespace NWNLogRotator
             if (Process.GetProcessesByName(Path.GetFileNameWithoutExtension(Assembly.GetEntryAssembly().Location)).Length > 1)
             {
                 MessageBox.Show("There is already an instance of NWNLogRotator running!");
+                ExitEvent();
                 Process.GetCurrentProcess().Kill();
             }
             InitializeComponent();
@@ -244,7 +245,10 @@ namespace NWNLogRotator
                     else
                     {
                         if(_settings.CloseOnLogGenerated == true )
+                        {
+                            ExitEvent();
                             Process.GetCurrentProcess().Kill();
+                        }
                     }
                         
                 }
@@ -489,8 +493,11 @@ namespace NWNLogRotator
                 }
 
                 if (_settings.SaveOnLaunch == false)
-                    if (_automatic && _settings.CloseOnLogGenerated == true) Process.GetCurrentProcess().Kill();
-
+                    if (_automatic && _settings.CloseOnLogGenerated == true)
+                    {
+                        ExitEvent();
+                        Process.GetCurrentProcess().Kill();
+                    }
                 if (_settings.Silent == false)
                 {
                     MessageBoxResult _messageBoxResult = MessageBox.Show("The log file has been generated successfully. Would you like to open the log file now?",
@@ -510,8 +517,12 @@ namespace NWNLogRotator
             }
             else
             {
-                if(_settings.SaveOnLaunch == false)
-                    if (_automatic && _settings.CloseOnLogGenerated == true) Process.GetCurrentProcess().Kill();
+                if (_settings.SaveOnLaunch == false)
+                    if (_automatic && _settings.CloseOnLogGenerated == true)
+                    {
+                        ExitEvent();
+                        Process.GetCurrentProcess().Kill();
+                    }
             }
 
             return false;
@@ -719,7 +730,12 @@ namespace NWNLogRotator
             base.OnStateChanged(e);
         }
 
-        private void WindowClosed_Event(object sender, CancelEventArgs e)
+        public void WindowClosed_Event(object sender, CancelEventArgs e)
+        {
+            ExitEvent();
+        }
+
+        public static void ExitEvent()
         {
             ni.Visible = false;
             ni.Icon = null;

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -49,5 +49,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.0.1")]
-[assembly: AssemblyFileVersion("0.1.0.1")]
+[assembly: AssemblyVersion("0.1.0.2")]
+[assembly: AssemblyFileVersion("0.1.0.2")]


### PR DESCRIPTION
For Windows 10 users, depending on how the app is closed, the tray icon may not properly dispose.